### PR TITLE
Fixed an issue with transparent backgrounds

### DIFF
--- a/Classes/UIImage+DHImageAdditions.m
+++ b/Classes/UIImage+DHImageAdditions.m
@@ -32,7 +32,7 @@
 {
 	UIImage *unifiedImage = nil;
 	CGSize totalImageSize = [self verticalAppendedTotalImageSizeFromImagesArray:imagesArray];
-	UIGraphicsBeginImageContextWithOptions(totalImageSize, YES, 0.f);
+	UIGraphicsBeginImageContextWithOptions(totalImageSize, NO, 0.f);
 	// For each image found in the array, create a new big image vertically
 	int imageOffsetFactor = 0;
 	for (UIImage *img in imagesArray) {


### PR DESCRIPTION
When screenshoting a tableview containing cells with a transparent background, the resulting `UIImage` had a black background instead of keeping transparency.
