### PR TITLE
Run layoutIfNeeded before renderInContext

### DIFF
--- a/Classes/UIView+DHSmartScreenshot.m
+++ b/Classes/UIView+DHSmartScreenshot.m
@@ -25,6 +25,7 @@
 	if (context == NULL) return nil;
     CGContextTranslateCTM(context, -croppingRect.origin.x, -croppingRect.origin.y);
 	
+	[self layoutIfNeeded];
 	[self.layer renderInContext:context];
 	
 	UIImage *screenshotImage = UIGraphicsGetImageFromCurrentImageContext();


### PR DESCRIPTION
Things like auto layout seem to work best if you call layoutIfNeeded before renderInContext.
